### PR TITLE
Attempted to create a platform agnostic async event via the RNG in the C++20 Coroutines example.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,4 +28,4 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   set(PLATFORM_HEADER "Windows.h")
 endif()
 
-configure_file(platform.h.in platform.h @ONLY)
+configure_file(platform_config.h.in platform_config.h @ONLY)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,27 +1,31 @@
 cmake_minimum_required (VERSION 3.16)
 project (SCoroTest LANGUAGES CXX)
 
-include_directories(${CMAKE_HOME_DIRECTORY})
+include_directories(${CMAKE_HOME_DIRECTORY} ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(SCoroGen generator.cpp)
 add_executable(SCoroTim timing.cpp)
 add_executable(SCoroEvn event.cpp)
 add_executable(SCoroCom composable.cpp)
 add_executable(SCoroThread swap_threads.cpp)
+add_executable(SCoroCoro coroutine_cpp20.cpp)
 
 set_property(TARGET SCoroGen PROPERTY CXX_STANDARD 20)
 set_property(TARGET SCoroTim PROPERTY CXX_STANDARD 20)
 set_property(TARGET SCoroEvn PROPERTY CXX_STANDARD 20)
 set_property(TARGET SCoroCom PROPERTY CXX_STANDARD 20)
 set_property(TARGET SCoroThread PROPERTY CXX_STANDARD 20)
+set_property(TARGET SCoroCoro PROPERTY CXX_STANDARD 20)
 
-if(UNIX)
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   target_link_libraries(SCoroThread -lpthread)
   target_link_libraries(SCoroEvn -lpthread)
+  set(PLATFORM_HEADER "unistd.h")
 endif()
 
-if(WIN32)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   add_compile_options("/await") # only for visual studio
-  add_executable(SCoroCoro coroutine_cpp20.cpp)
-  set_property(TARGET SCoroCoro PROPERTY CXX_STANDARD 20)
+  set(PLATFORM_HEADER "Windows.h")
 endif()
+
+configure_file(platform.h.in platform.h @ONLY)

--- a/examples/coroutine_cpp20.cpp
+++ b/examples/coroutine_cpp20.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <random>
 #include <string>
-#include <sleep.h>
+#include <platform_config.h>
 
 using default_handle = std::coroutine_handle<>;
 

--- a/examples/platform_config.h.in
+++ b/examples/platform_config.h.in
@@ -1,0 +1,2 @@
+// Platform specifc configs
+#include <@PLATFORM_HEADER@>


### PR DESCRIPTION
Attempted to create a platform agnostic async event via the RNG. Moved away from std::experimental namespace. Cannot co_yield void in gcc/clang. Moved to more portable platform determination in CMake.

Hoping I didn't break anything Windows specific but I don't have a Windows box I can test on at the moment. Also, you may have a better idea than the RNG approach but it does have advantage of being easily scripted at least.